### PR TITLE
Fixes #1

### DIFF
--- a/echotorch/__init__.py
+++ b/echotorch/__init__.py
@@ -2,10 +2,10 @@
 #
 
 # Imports
-import datasets
-import models
-import nn
-import utils
+from . import datasets
+from . import models
+from . import nn
+from . import utils
 
 
 # All EchoTorch's modules

--- a/echotorch/datasets/__init__.py
+++ b/echotorch/datasets/__init__.py
@@ -8,5 +8,5 @@ from .MemTestDataset import MemTestDataset
 from .NARMADataset import NARMADataset
 
 __all__ = [
-    'LogisticMapDataset', 'MackeyGlassDataset', 'MemTestDataset', 'NARMADataset'
+   'LogisticMapDataset', 'MackeyGlassDataset', 'MemTestDataset', 'NARMADataset'
 ]

--- a/echotorch/models/__init__.py
+++ b/echotorch/models/__init__.py
@@ -20,5 +20,5 @@
 # Copyright Nils Schaetti, University of Neuchâtel <nils.schaetti@unine.ch>
 
 # Imports
-from HNilsNet import HNilsNet
-from NilsNet import NilsNet
+from .HNilsNet import HNilsNet
+from .NilsNet import NilsNet

--- a/echotorch/nn/BDESN.py
+++ b/echotorch/nn/BDESN.py
@@ -30,7 +30,7 @@ import torch
 import torch.nn as nn
 from torch.autograd import Variable
 from .BDESNCell import BDESNCell
-from RRCell import RRCell
+from .RRCell import RRCell
 
 
 # Bi-directional Echo State Network module

--- a/echotorch/nn/BDESNCell.py
+++ b/echotorch/nn/BDESNCell.py
@@ -28,7 +28,7 @@ Created on 26 January 2018
 import torch.sparse
 import torch
 import torch.nn as nn
-from LiESNCell import LiESNCell
+from .LiESNCell import LiESNCell
 import numpy as np
 from torch.autograd import Variable
 

--- a/echotorch/nn/ESN.py
+++ b/echotorch/nn/ESN.py
@@ -30,7 +30,7 @@ import torch
 import torch.nn as nn
 from torch.autograd import Variable
 from . import ESNCell
-from RRCell import RRCell
+from .RRCell import RRCell
 
 
 # Echo State Network module

--- a/echotorch/nn/StackedESN.py
+++ b/echotorch/nn/StackedESN.py
@@ -31,8 +31,8 @@ import torch.nn as nn
 import echotorch.utils
 from torch.autograd import Variable
 from . import LiESNCell
-from RRCell import RRCell
-from ESNCell import ESNCell
+from .RRCell import RRCell
+from .ESNCell import ESNCell
 import numpy as np
 
 


### PR DESCRIPTION
This fixes Issue #1 by changing all local imports to use the explicit relative import syntax. 

I've not tested this with any Python version < 3.5, but from what I can tell, the syntax is compatible with 2.7 onward.