### PR TITLE
Ignore .venv for better integration with package managers such as uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Package mangers such as uv create venvs via a .venv folder. This is to ignore those virtual environments as well.